### PR TITLE
fix: skip json/object resources in extractArchiveAndGetURL

### DIFF
--- a/.changeset/purple-colts-pick.md
+++ b/.changeset/purple-colts-pick.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.fastqc.model': minor
+---
+
+Skip json/object resources before calling extractArchiveAndGetURL('zip') in FastQCzipR1 and FastQCzipR2 outputs

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,9 +1,15 @@
-import type { InferOutputsType, PlRef } from '@platforma-sdk/model';
+import type { InferOutputsType, PlRef, TreeNodeAccessor } from '@platforma-sdk/model';
 import {
   BlockModel,
   isPColumnSpec,
   parseResourceMap,
 } from '@platforma-sdk/model';
+
+/** Extract zip archive URL, skipping non-blob resources (e.g. empty json/object from single-end data with no R2) */
+const extractZipURL = (acc: TreeNodeAccessor) => {
+  if (acc.resourceType.name === 'json/object') return undefined;
+  return acc.extractArchiveAndGetURL('zip');
+};
 
 // Block arguments coming from the user interface
 export type BlockArgs = {
@@ -85,29 +91,19 @@ export const model = BlockModel.create()
   .output('FastQCzipR1', (wf) => {
     return parseResourceMap(
       wf.outputs?.resolve('FastQCzipR1'),
-      (acc) => {
-        // Skip non-blob resources (e.g. empty json/object from single-end data with no R2)
-        if (acc.resourceType.name === 'json/object') return undefined;
-        return acc.extractArchiveAndGetURL('zip');
-      },
+      extractZipURL,
       false,
     );
-  },
-  )
+  })
 
   // Reference to zip file with html content created by FastQC
   .output('FastQCzipR2', (wf) => {
     return parseResourceMap(
       wf.outputs?.resolve('FastQCzipR2'),
-      (acc) => {
-        // Skip non-blob resources (e.g. empty json/object from single-end data with no R2)
-        if (acc.resourceType.name === 'json/object') return undefined;
-        return acc.extractArchiveAndGetURL('zip');
-      },
+      extractZipURL,
       false,
     );
-  },
-  )
+  })
 
   .sections([
     { type: 'link', href: '/', label: 'Main' },

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -85,7 +85,11 @@ export const model = BlockModel.create()
   .output('FastQCzipR1', (wf) => {
     return parseResourceMap(
       wf.outputs?.resolve('FastQCzipR1'),
-      (acc) => acc.extractArchiveAndGetURL('zip'),
+      (acc) => {
+        // Skip non-blob resources (e.g. empty json/object from single-end data with no R2)
+        if (acc.resourceType.name === 'json/object') return undefined;
+        return acc.extractArchiveAndGetURL('zip');
+      },
       false,
     );
   },
@@ -95,7 +99,11 @@ export const model = BlockModel.create()
   .output('FastQCzipR2', (wf) => {
     return parseResourceMap(
       wf.outputs?.resolve('FastQCzipR2'),
-      (acc) => acc.extractArchiveAndGetURL('zip'),
+      (acc) => {
+        // Skip non-blob resources (e.g. empty json/object from single-end data with no R2)
+        if (acc.resourceType.name === 'json/object') return undefined;
+        return acc.extractArchiveAndGetURL('zip');
+      },
       false,
     );
   },


### PR DESCRIPTION
## Summary

- Skip `json/object` resources before calling `extractArchiveAndGetURL('zip')` in `FastQCzipR1` and `FastQCzipR2` outputs
- When single-end sequencing data has no R2, the workflow returns `{}` which becomes a `json/object:1` resource — calling blob download on it causes a gRPC `UNIMPLEMENTED` error

## Context

**Sentry issue**: https://sn.pl-open.science/organizations/sentry/issues/PLATFORM-ELECTRON-7N
- Related platform fix: adding `UNIMPLEMENTED` to non-recoverable errors in `core/platforma`
- This fix prevents the bad gRPC call from being made in the first place

## Test plan

- [ ] Run FastQC block with single-end data (no R2) — should not produce gRPC errors
- [ ] Run FastQC block with paired-end data — R1 and R2 zips should still render correctly